### PR TITLE
Client TLS cert support

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -304,6 +304,7 @@ if __name__ == "__main__":
     parser.add_argument('--debug', '-d', action='store_true', help='enforce debugging output')
     parser.add_argument('--voucher', type=str, required=False, help='voucher to use to automatically register')
     parser.add_argument('--url', type=str, required=False, help='URL to Hashtopolis client API')
+    parser.add_argument('--cert', type=str, required=False, help='Client TLS cert bundle for Hashtopolis client API')
     args = parser.parse_args()
 
     if args.version:

--- a/htpclient/initialize.py
+++ b/htpclient/initialize.py
@@ -19,6 +19,7 @@ class Initialize:
         return "0.6.0"
 
     def run(self, args):
+        self.__check_cert(args)
         self.__check_url(args)
         self.__check_token(args)
         self.__update_information()
@@ -167,6 +168,18 @@ class Initialize:
                 self.config.set_value('voucher', '')
                 self.config.set_value('token', token)
                 logging.info("Successfully registered!")
+
+    def __check_cert(self, args):
+        cert = self.config.get_value('cert')
+        if cert is None:
+            if args.cert is not None:
+                cert = os.path.abspath(args.cert)
+                logging.debug("Setting cert to: " + cert)
+                self.config.set_value('cert', cert)
+                
+        if cert is not None:
+            Session().s.cert = cert
+            logging.debug("Configuration session cert to: " + cert)
 
     def __check_url(self, args):
         if not self.config.get_value('url'):


### PR DESCRIPTION
Added client TLS certificate support by adding a main argument for adding a client cert bundle and the check feature in initialize.py to check and update the session() cert property from the configuration. 

I've been updating my agent zip to include a cert.pem bundle and a config with the url and cert values already populated and it's worked quite well for my uses. No worries of exposing hashtopolis to the internet, while allowing remote agents without the managing of IP based firewall lists. 