### PR TITLE
Added local hashcat support in macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ __pycache__
 .idea
 venv
 lock.pid
+.DS_Store

--- a/htpclient/hashcat_cracker.py
+++ b/htpclient/hashcat_cracker.py
@@ -32,13 +32,13 @@ class HashcatCracker:
             self.callPath = "./" + self.callPath
 
 		# Symlink hashcat.osx in macOS
-		if not os.path.isfile(self.cracker_path + "hashcat.osx"):
-			if Initialize.get_os() == 2: # macOS
-				try:
-					output = subprocess.check_output("ln -s $(which hashcat) hashcat.osx", shell=True, cwd=self.cracker_path)
-				except subprocess.CalledProcessError as e:
-					logging.error("Error during version detection: " + str(e))
-					sleep(5)
+        if not os.path.isfile(self.cracker_path + "hashcat.osx"):  # in case it's not the
+            if Initialize.get_os() == 2: # macOS
+                try:
+                    output = subprocess.check_output("ln -s $(which hashcat) hashcat.osx", shell=True, cwd=self.cracker_path)
+                except subprocess.CalledProcessError as e:
+                    logging.error("Error during version detection: " + str(e))
+                    sleep(5)
 		
         if not os.path.isfile(self.cracker_path + self.callPath):  # in case it's not the new hashcat filename, try the old one (hashcat<bit>.<ext>)
             self.executable_name = binary_download.get_version()['executable']

--- a/htpclient/hashcat_cracker.py
+++ b/htpclient/hashcat_cracker.py
@@ -31,6 +31,15 @@ class HashcatCracker:
         if Initialize.get_os() != 1:
             self.callPath = "./" + self.callPath
 
+		# Symlink hashcat.osx in macOS
+		if not os.path.isfile(self.cracker_path + "hashcat.osx"):
+			if Initialize.get_os() == 2: # macOS
+				try:
+					output = subprocess.check_output("ln -s $(which hashcat) hashcat.osx", shell=True, cwd=self.cracker_path)
+				except subprocess.CalledProcessError as e:
+					logging.error("Error during version detection: " + str(e))
+					sleep(5)
+		
         if not os.path.isfile(self.cracker_path + self.callPath):  # in case it's not the new hashcat filename, try the old one (hashcat<bit>.<ext>)
             self.executable_name = binary_download.get_version()['executable']
             k = self.executable_name.rfind(".")

--- a/htpclient/initialize.py
+++ b/htpclient/initialize.py
@@ -118,6 +118,22 @@ class Initialize:
                 devices.append(line)
 
         else:  # OS X
+            logging.info("Check if Homebrew is installed...")
+            output = subprocess.check_output("type brew", shell=True)
+            output = output.decode(encoding='utf-8').replace("\r\n", "\n").split("\n")
+            for line in output:
+            	line = line.rstrip("\r\n ")
+            	if "not found" in line:
+            		log_error_and_exit("Please install Homebrew first. Visit https://brew.sh for instructions.")
+            
+            logging.info("Check if hashcat is installed via Homebrew...")
+            output = subprocess.check_output("brew info hashcat", shell=True)
+            output = output.decode(encoding='utf-8').replace("\r\n", "\n").split("\n")
+            for line in output:
+            	line = line.rstrip("\r\n ")
+            	if line == "Not installed":
+            		log_error_and_exit("Please install hashcat via Homebrew first: brew install hashcat")
+            
             output = subprocess.check_output("system_profiler -detaillevel mini", shell=True)
             output = output.decode(encoding='utf-8').replace("\r\n", "\n").split("\n")
             for line in output:


### PR DESCRIPTION
- In the initialization process, check if Homebrew and hashcat are installed. If not installed, hint the user to install before continue.
- In Hashcat_Cracker, symlink the local hashcat with the missing "hashcat.osx". (TODO: Compare hashcat version)