### PR TITLE
Bugfix parsing hashcat status

### DIFF
--- a/htpclient/hashcat_status.py
+++ b/htpclient/hashcat_status.py
@@ -39,6 +39,8 @@ class HashcatStatus:
             while line[index] != "REJECTED":
                 self.temp.append(int(line[index]))
                 index += 1
+        else:
+            index += 11
         self.rejected = int(line[index + 1])
         if len(line) > index + 2:
             index += 2


### PR DESCRIPTION
When no TEMP values are passed along in the hashcat status, increase the index to ensure proper alignment to parse the rest of the status message