### PR TITLE
Fix cert code to read from args correctly

### DIFF
--- a/htpclient/initialize.py
+++ b/htpclient/initialize.py
@@ -188,13 +188,13 @@ class Initialize:
 
     def __check_cert(self, args):
         cert = self.config.get_value('cert')
-        if cert is None:
+        if not cert:
             if args.cert is not None:
                 cert = os.path.abspath(args.cert)
                 logging.debug("Setting cert to: " + cert)
                 self.config.set_value('cert', cert)
                 
-        if cert is not None:
+        if cert:
             Session().s.cert = cert
             logging.debug("Configuration session cert to: " + cert)
 


### PR DESCRIPTION
Fix bug in the client cert code that was merged a while back. The is None check never succeeds and thus certs only work from config.json without this bug fix.  