### PR TITLE
Making agent work with hashcat 7/master

### DIFF
--- a/htpclient/hashcat_status.py
+++ b/htpclient/hashcat_status.py
@@ -47,6 +47,9 @@ class HashcatStatus:
             if line[index] == "UTIL":
                 index += 1
                 while len(line) - 1 > index:  # -1 because the \r\n is also included in the split
+                    # Hashcat 7 has extra parameter where we expect utils of cards
+                    if line[index] == "POWER": 
+                        break
                     self.util.append(int(line[index]))
                     index += 1
 


### PR DESCRIPTION
In https://github.com/hashcat/hashcat/blob/1cb65904245eab2aecda0d5a87b2276342768bcb/src/terminal.c#L2723
hashcat also introduces an extra parameter called power where we are expecting util of all cards. This fixes it.